### PR TITLE
Ace decode error fix for Qumulo Core 1.2.16

### DIFF
--- a/qacls_config.py
+++ b/qacls_config.py
@@ -15,8 +15,8 @@ AD_USER_BASE_DN = "CN=users, DC=demo, DC=int"
 AD_GROUP_BASE_DN = "CN=users, DC=demo, DC=int"
 
 CONTROL_DEFAULT = [
-    #"PRESENT",
-    #"AUTO_INHERIT"
+    "QFS_ACL_CONTROL_PRESENT",
+    "QFS_ACL_CONTROL_AUTO_INHERIT"
 ]
 
 # Repeatable sets of rights


### PR DESCRIPTION
This version only confirmed to work with Qumulo Core and Python library for 1.2.16
